### PR TITLE
docs: add home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
-# Home
+<!-- Embed content from the README.md file. -->
 
-A Python client for communicating with DSIS.
+<!--
+Disable markdownlint rule MD041: "First line in a file should be a top-level heading".
+The README.md file already contains a top-level heading.
+-->
+<!-- markdownlint-disable MD041 -->
+
+--8<-- "README.md"


### PR DESCRIPTION
Embed content from `README.md` on the documentation home page - allows us to maintain a single home page for both the repository and documentation site.