### PR TITLE
chore: add `Launch docs` debug profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,9 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch docs",
       "type": "debugpy",
       "request": "launch",
+      "name": "Launch docs",
       "module": "mkdocs",
       "args": ["serve"],
       "serverReadyAction": {


### PR DESCRIPTION
Add a debug profile that runs a local MkDocs development server, then opens the site in your web browser.