### PR TITLE
ci: publish docs on any change

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,11 +3,8 @@ name: Publish Docs
 on:
   pull_request:
     branches: [main]
-    paths: [docs/**, mkdocs.yml]
-
   push:
     branches: [main]
-    paths: [docs/**, mkdocs.yml]
 
 permissions: {}
 


### PR DESCRIPTION
Remove filter that publishes docs on changes to `mkdocs.yml` and `docs/**` only. Required for docs to be published on changes to `README.md` or `CHANGELOG.md` - both files are rendered on our docs site.

Instead of updating the filter, remove it so that we don't have to maintain it whenever our MkDocs site references files outside of the `docs` directory.