### PR TITLE
refactor: remove unused top() and skip() methods

### DIFF
--- a/docs/guides/query-builder.md
+++ b/docs/guides/query-builder.md
@@ -130,22 +130,6 @@ query.expand("wellbores")
 query.expand("wellbores,interpretations")
 ```
 
-### top()
-
-Limit number of results.
-
-```python
-query.top(100)  # Return max 100 items
-```
-
-### skip()
-
-Skip first N results (pagination).
-
-```python
-query.skip(50)  # Skip first 50 items
-```
-
 ### reset()
 
 Clear query parameters for reuse.
@@ -220,7 +204,6 @@ query = (
     .schema("Well")
     .select("well_name,well_uwi,spud_date")
     .filter("well_type eq 'Producer'")
-    .top(50)
 )
 
 response = client.execute_query(query)


### PR DESCRIPTION
This pull request updates the `query-builder.md` documentation to remove references to the `top()` and `skip()` methods, which do not exist in the code base. 

Documentation cleanup:

* Removed the sections describing the `top()` and `skip()` methods, including example usage and explanations, from `docs/guides/query-builder.md`.

Example update:

* Removed the `.top(50)` method call from the example query in `docs/guides/query-builder.md`.