### PR TITLE
feat: make json format optional in stead of a forced default

### DIFF
--- a/docs/guides/query-builder.md
+++ b/docs/guides/query-builder.md
@@ -130,6 +130,23 @@ query.expand("wellbores")
 query.expand("wellbores,interpretations")
 ```
 
+### format()
+
+Set the response format parameter.
+
+```python
+# Default: json format (included by default)
+query = QueryBuilder(district_id=dist, field=fld).schema("Well").select("well_name")
+# Result: Well?$format=json&$select=well_name
+
+# Explicitly set to json
+query.format("json")
+
+# Omit format parameter entirely
+query.format("")  # or .format(None)
+# Result: Well?$select=well_name
+```
+
 ### reset()
 
 Clear query parameters for reuse.

--- a/src/dsis_client/api/query/builder.py
+++ b/src/dsis_client/api/query/builder.py
@@ -44,7 +44,7 @@ class QueryBuilder:
         self._select: List[str] = []
         self._expand: List[str] = []
         self._filter: Optional[str] = None
-        self._format = "json"
+        self._format: Optional[str] = "json"
 
     def schema(self, schema: Union[str, Type]) -> "QueryBuilder":
         """Set the schema (data table) using a name or model class.
@@ -130,14 +130,21 @@ class QueryBuilder:
         logger.debug(f"Set filter: {filter_expr}")
         return self
 
-    def format(self, format_type: str) -> "QueryBuilder":
+    def format(self, format_type: Optional[str] = "json") -> "QueryBuilder":
         """Set the response format.
 
         Args:
-            format_type: Format type (default: "json")
+            format_type: Format type ("json", empty string to omit, or None).
+                Defaults to "json".
 
         Returns:
             Self for chaining
+
+        Example:
+            >>> builder.format()  # Use default "json"
+            >>> builder.format("json")  # Explicitly set to json
+            >>> builder.format("")  # Omit format parameter from query
+            >>> builder.format(None)  # Omit format parameter from query
         """
         self._format = format_type
         logger.debug(f"Set format: {format_type}")
@@ -199,7 +206,7 @@ class QueryBuilder:
         self._select = []
         self._expand = []
         self._filter = None
-        self._format = "json"
+        self._format: Optional[str] = "json"
         logger.debug("Reset builder")
         return self
 

--- a/src/dsis_client/api/query/odata.py
+++ b/src/dsis_client/api/query/odata.py
@@ -11,7 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 def build_query_params(
-    select: list, expand: list, filter_expr: str, format_type: str = "json"
+    select: list,
+    expand: list,
+    filter_expr: str,
+    format_type: str = "json",
 ) -> Dict[str, str]:
     """Build OData query parameters dictionary.
 
@@ -19,12 +22,17 @@ def build_query_params(
         select: List of fields to select
         expand: List of relations to expand
         filter_expr: OData filter expression
-        format_type: Response format (default: "json")
+        format_type: Response format (default: "json"). Use None or empty
+            string to omit the $format parameter.
 
     Returns:
         Dictionary of query parameters
     """
-    params: Dict[str, str] = {"$format": format_type}
+    params: Dict[str, str] = {}
+
+    # Only add format if it's not None or empty
+    if format_type:
+        params["$format"] = format_type
 
     if select:
         params["$select"] = ",".join(select)


### PR DESCRIPTION
We cannot download the bin files from the endpoint if format is set to json, so we have to make this an optional parameter in the endpoint. 

**QueryBuilder API improvements:**

* Added support in `QueryBuilder.format()` to omit the `$format` parameter by passing an empty string or `None`, and updated the default to `"json"`.

**Query parameter construction:**

* Modified `build_query_params` in `odata.py` to only include the `$format` parameter if it is not empty or `None`.

**Documentation updates:**

* Added a new section to `query-builder.md` documenting how to use the `.format()` method, including examples for omitting the parameter.