### PR TITLE
feat: implement retry logic for HTTP requests on token expiry

### DIFF
--- a/src/dsis_client/api/client/_http.py
+++ b/src/dsis_client/api/client/_http.py
@@ -39,7 +39,7 @@ class HTTPTransportMixin:
         params: Optional[Dict[str, Any]] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         stream: bool = False,
-        request_type: str = "request",
+        request_type: str = "standard",
     ) -> "requests.Response":
         """Make an HTTP GET request with automatic token refresh retry.
 


### PR DESCRIPTION
APIM has only an hour lifespan for the dsis token. Some runs takes longer than that and some of the data fetching breaks because of it. This should help mitigate this. 

Key improvements:

**Automatic Token Refresh and Retry Logic**
* Added a private method `_make_request_with_retry` to `HTTPTransportMixin` that handles GET requests, automatically refreshing tokens and retrying once on 401 or 500 status codes.

**Consistent Use of Retry Logic in Requests**
* Updated the `_request`, `_request_binary`, and `_request_binary_stream` methods to use `_make_request_with_retry`, ensuring all GET requests benefit from the new retry mechanism. 

**Type Annotation Updates**
* Updated the return type of `_request_binary_stream` to `Generator[bytes, None, None]` for better type safety and clarity.
