### PR TITLE
feat: change header accept

### DIFF
--- a/src/dsis_client/api/client/_base.py
+++ b/src/dsis_client/api/client/_base.py
@@ -41,7 +41,10 @@ class _BinaryRequestBase:
         config: "DSISConfig"
 
         def _request_binary(
-            self, endpoint: str, params: Optional[Dict[str, Any]] = None
+            self,
+            endpoint: str,
+            params: Optional[Dict[str, Any]] = None,
+            accept: str = "application/json",
         ) -> Optional[bytes]: ...
 
         def _request_binary_stream(
@@ -49,4 +52,5 @@ class _BinaryRequestBase:
             endpoint: str,
             params: Optional[Dict[str, Any]] = None,
             chunk_size: int = 10 * 1024 * 1024,
+            accept: str = "application/json",
         ) -> Generator[bytes, None, None]: ...

--- a/src/dsis_client/api/client/_bulk_data.py
+++ b/src/dsis_client/api/client/_bulk_data.py
@@ -113,6 +113,7 @@ class BulkDataMixin(_BinaryRequestBase):
         project: Optional[str] = None,
         data_field: str = "data",
         query: Optional["QueryBuilder"] = None,
+        accept: str = "application/json",
     ) -> Optional[bytes]:
         """Fetch binary bulk data (protobuf) for a specific entity.
 
@@ -137,6 +138,9 @@ class BulkDataMixin(_BinaryRequestBase):
             data_field: Name of the binary data field (default: "data")
             query: Optional QueryBuilder instance to extract district_id and project from.
                    If provided, district_id and project parameters are ignored.
+            accept: Accept header value for the HTTP request
+                (default: "application/json"). Use "application/octet-stream"
+                for endpoints that serve raw binary data (e.g., SurfaceGrid /$value).
 
         Returns:
             Binary protobuf data as bytes, or None if the entity has no bulk data
@@ -185,7 +189,7 @@ class BulkDataMixin(_BinaryRequestBase):
         )
 
         logger.info(f"Fetching bulk data from: {endpoint}")
-        return self._request_binary(endpoint)
+        return self._request_binary(endpoint, accept=accept)
 
     def get_bulk_data_stream(
         self,
@@ -196,6 +200,7 @@ class BulkDataMixin(_BinaryRequestBase):
         data_field: str = "data",
         chunk_size: int = 10 * 1024 * 1024,
         query: Optional["QueryBuilder"] = None,
+        accept: str = "application/json",
     ) -> Generator[bytes, None, None]:
         """Stream binary bulk data (protobuf) in chunks for memory-efficient processing.
 
@@ -225,6 +230,9 @@ class BulkDataMixin(_BinaryRequestBase):
                 (default: 10MB, recommended by DSIS)
             query: Optional QueryBuilder instance to extract district_id and project from.
                    If provided, district_id and project parameters are ignored.
+            accept: Accept header value for the HTTP request
+                (default: "application/json"). Use "application/octet-stream"
+                for endpoints that serve raw binary data (e.g., SurfaceGrid /$value).
 
         Yields:
             Binary data chunks as bytes. Returns immediately if no bulk data (404).
@@ -276,4 +284,4 @@ class BulkDataMixin(_BinaryRequestBase):
         )
 
         logger.info(f"Streaming bulk data from: {endpoint} (chunk_size={chunk_size})")
-        yield from self._request_binary_stream(endpoint, chunk_size=chunk_size)
+        yield from self._request_binary_stream(endpoint, chunk_size=chunk_size, accept=accept)

--- a/src/dsis_client/api/client/_bulk_data.py
+++ b/src/dsis_client/api/client/_bulk_data.py
@@ -284,4 +284,6 @@ class BulkDataMixin(_BinaryRequestBase):
         )
 
         logger.info(f"Streaming bulk data from: {endpoint} (chunk_size={chunk_size})")
-        yield from self._request_binary_stream(endpoint, chunk_size=chunk_size, accept=accept)
+        yield from self._request_binary_stream(
+            endpoint, chunk_size=chunk_size, accept=accept
+        )

--- a/src/dsis_client/api/client/_http.py
+++ b/src/dsis_client/api/client/_http.py
@@ -131,19 +131,24 @@ class HTTPTransportMixin:
                 )
 
     def _request_binary(
-        self, endpoint: str, params: Optional[Dict[str, Any]] = None
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        accept: str = "application/json",
     ) -> Optional[bytes]:
         """Make an authenticated GET request for binary data.
 
         Internal method for fetching binary protobuf data from the DSIS API.
         Automatically retries once with refreshed tokens on 401 or 500 errors.
 
-        Note: The DSIS API returns binary protobuf data with Accept: application/json,
-        not application/octet-stream. This is the actual behavior observed in the API.
+        Note: The DSIS API typically returns binary protobuf data with
+        Accept: application/json. For some endpoints (e.g., SurfaceGrid /$value),
+        "application/octet-stream" may be required instead.
 
         Args:
             endpoint: API endpoint path
             params: Query parameters
+            accept: Accept header value (default: "application/json")
 
         Returns:
             Binary response content, or None if the entity has no bulk data (404)
@@ -156,7 +161,7 @@ class HTTPTransportMixin:
         response = self._make_request_with_retry(
             url,
             params,
-            extra_headers={"Accept": "application/json"},
+            extra_headers={"Accept": accept},
             request_type="binary",
         )
 
@@ -179,19 +184,22 @@ class HTTPTransportMixin:
         endpoint: str,
         params: Optional[Dict[str, Any]] = None,
         chunk_size: int = 10 * 1024 * 1024,
+        accept: str = "application/json",
     ) -> Generator[bytes, None, None]:
         """Stream binary data in chunks to avoid loading large datasets into memory.
 
         Internal method for streaming binary protobuf data from the DSIS API.
         Automatically retries once with refreshed tokens on 401 or 500 errors.
 
-        Note: The DSIS API returns binary protobuf data with Accept: application/json,
-        not application/octet-stream. This is the actual behavior observed in the API.
+        Note: The DSIS API typically returns binary protobuf data with
+        Accept: application/json. For some endpoints (e.g., SurfaceGrid /$value),
+        "application/octet-stream" may be required instead.
 
         Args:
             endpoint: API endpoint path
             params: Query parameters
             chunk_size: Size of chunks to yield (default: 10MB, recommended by DSIS)
+            accept: Accept header value (default: "application/json")
 
         Yields:
             Binary data chunks as bytes
@@ -205,7 +213,7 @@ class HTTPTransportMixin:
         response = self._make_request_with_retry(
             url,
             params,
-            extra_headers={"Accept": "application/json"},
+            extra_headers={"Accept": accept},
             stream=True,
             request_type="streaming",
         )


### PR DESCRIPTION
**API flexibility and interface changes:**

* Added an `accept` parameter (defaulting to `"application/json"`) to the `_request_binary` and `_request_binary_stream` methods in `_http.py` and `_base.py`, allowing callers to override the `Accept` header for binary data requests. This because the api sometimes want the accept="application/octet-stream" variant.
* Updated the `get_bulk_data` and `get_bulk_data_stream` methods in `_bulk_data.py` to accept and forward the `accept` parameter, enabling users to specify the desired response content type. 
 
**Documentation improvements:**

* Expanded docstrings for all affected methods to document the new `accept` parameter, including guidance on when to use `"application/octet-stream"` for endpoints serving raw binary data. 

**Internal logic updates:**

* Modified internal request logic to use the provided `accept` value when setting the `Accept` header, instead of always defaulting to `"application/json"`.