### PR TITLE
docs: fix dependency name for DSIS models library

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install dsis-client
 For protobuf bulk data decoding (grids, horizons, seismic):
 
 ```bash
-pip install dsis-model-sdk[protobuf]
+pip install dsis-schemas[protobuf]
 ```
 
 ## Quick Start


### PR DESCRIPTION
The suggested command in the current documentation points to a library that does not exist in pypi - the exposed module name is `dsis_model_sdk` but the pypi package name is `dsis-schemas`