### PR TITLE
feat(auth): expose timeout configuration for token requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ config = DSISConfig(
     subscription_key_dsauth=os.getenv("DSIS_SUBSCRIPTION_KEY_DSAUTH"),
     subscription_key_dsdata=os.getenv("DSIS_SUBSCRIPTION_KEY_DSDATA"),
     dsis_site="qa",
+    auth_timeout=(5, 30),  # Optional: bound Azure AD + DSIS token requests
 )
 
 client = DSISClient(config)
@@ -134,6 +135,15 @@ for chunk in client.get_bulk_data_stream(
 Set `stream_retries` to retry transient failures while reading streamed chunks.
 Retries reopen the stream and assume the endpoint returns the same bytes across reconnects.
 The `timeout` value on streamed downloads applies to connection setup and waiting for the next bytes, not to the full transfer duration.
+
+For authentication, set `auth_timeout` on `DSISConfig` to bound Azure AD token acquisition and DSIS token refresh requests:
+
+```python
+config = DSISConfig(
+    ...,
+    auth_timeout=(5, 30),  # (connect_timeout, read_timeout)
+)
+```
 
 ## Error Handling
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -82,6 +82,7 @@ cfg = DSISConfig(
     subscription_key_dsauth=os.getenv("DSIS_SUBSCRIPTION_KEY_DSAUTH"),
     subscription_key_dsdata=os.getenv("DSIS_SUBSCRIPTION_KEY_DSDATA"),
     dsis_site="qa",
+    auth_timeout=(5, 30),
 )
 client = DSISClient(cfg)
 data = client.get("OW5000", "<record-id>")
@@ -105,6 +106,15 @@ data = client.get("OW5000", "5000107", schema="Well", timeout=60)
 - `None` (default): no timeout
 - `float`: both connect and read timeout
 - `(float, float)`: separate connect and read timeouts
+
+Authentication requests use `DSISConfig.auth_timeout`. Set it when you also want bounded Azure AD token acquisition and DSIS token refresh calls:
+
+```python
+cfg = DSISConfig(
+    ...,
+    auth_timeout=(5, 30),
+)
+```
 
 ## Error Handling Hint
 

--- a/src/dsis_client/api/auth/auth.py
+++ b/src/dsis_client/api/auth/auth.py
@@ -53,6 +53,7 @@ class DSISAuth:
             self.config.client_id,
             authority=self.config.authority,
             client_credential=self.config.client_secret,
+            timeout=self.config.auth_timeout,
         )
 
         result = app.acquire_token_for_client(scopes=self.config.scope)
@@ -103,7 +104,10 @@ class DSISAuth:
         }
 
         response = self._session.post(
-            self.config.token_endpoint, headers=headers, data=body
+            self.config.token_endpoint,
+            headers=headers,
+            data=body,
+            timeout=self.config.auth_timeout,
         )
 
         if response.status_code != 200:

--- a/src/dsis_client/api/config/config.py
+++ b/src/dsis_client/api/config/config.py
@@ -26,6 +26,9 @@ class DSISConfig:
         subscription_key_dsauth: APIM subscription key for dsauth endpoint
         subscription_key_dsdata: APIM subscription key for dsdata endpoint
         dsis_site: DSIS site header (default: "qa")
+        auth_timeout: Optional timeout for Azure AD and DSIS token requests.
+            Accepts the same forms as requests timeouts: None, a single float,
+            or a (connect, read) tuple.
     """
 
     # Environment settings
@@ -47,6 +50,9 @@ class DSISConfig:
 
     # DSIS site header (typically "qa" for DEV endpoint)
     dsis_site: str = "qa"
+
+    # Optional timeout for token acquisition/refresh requests
+    auth_timeout: float | tuple[float, float] | None = None
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,29 +10,29 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src" / "dsis_client" / "api"
 
 
-def load_auth_types():
-    """Load auth/config modules directly from source without package side effects."""
+def load_auth_types(monkeypatch):
+    """Load auth/config modules directly from source for isolated auth tests."""
     for name in list(sys.modules):
         if name == "dsis_client" or name.startswith("dsis_client."):
-            sys.modules.pop(name)
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
     dsis_pkg = types.ModuleType("dsis_client")
     dsis_pkg.__path__ = [str(ROOT / "src" / "dsis_client")]
-    sys.modules["dsis_client"] = dsis_pkg
+    monkeypatch.setitem(sys.modules, "dsis_client", dsis_pkg)
 
     api_pkg = types.ModuleType("dsis_client.api")
     api_pkg.__path__ = [str(SRC)]
-    sys.modules["dsis_client.api"] = api_pkg
+    monkeypatch.setitem(sys.modules, "dsis_client.api", api_pkg)
     dsis_pkg.api = api_pkg
 
     config_pkg = types.ModuleType("dsis_client.api.config")
     config_pkg.__path__ = [str(SRC / "config")]
-    sys.modules["dsis_client.api.config"] = config_pkg
+    monkeypatch.setitem(sys.modules, "dsis_client.api.config", config_pkg)
     api_pkg.config = config_pkg
 
     auth_pkg = types.ModuleType("dsis_client.api.auth")
     auth_pkg.__path__ = [str(SRC / "auth")]
-    sys.modules["dsis_client.api.auth"] = auth_pkg
+    monkeypatch.setitem(sys.modules, "dsis_client.api.auth", auth_pkg)
     api_pkg.auth = auth_pkg
 
     def load_module(name: str, path: Path):
@@ -40,7 +40,7 @@ def load_auth_types():
         if spec is None or spec.loader is None:
             raise RuntimeError(f"Unable to load module {name} from {path}")
         module = module_from_spec(spec)
-        sys.modules[name] = module
+        monkeypatch.setitem(sys.modules, name, module)
         spec.loader.exec_module(module)
         return module
 
@@ -59,7 +59,13 @@ def load_auth_types():
     auth_module = load_module("dsis_client.api.auth.auth", SRC / "auth" / "auth.py")
     auth_pkg.auth = auth_module
     auth_pkg.DSISAuth = auth_module.DSISAuth
-    return auth_module.DSISAuth, config_module.DSISConfig, environment_module.Environment
+
+    return (
+        auth_module,
+        auth_module.DSISAuth,
+        config_module.DSISConfig,
+        environment_module.Environment,
+    )
 
 
 def make_config(
@@ -86,7 +92,7 @@ def make_config(
 
 def test_get_aad_token_uses_configured_auth_timeout(monkeypatch):
     """MSAL client creation forwards auth_timeout from DSISConfig."""
-    DSISAuth, DSISConfig, Environment = load_auth_types()
+    auth_module, DSISAuth, DSISConfig, Environment = load_auth_types(monkeypatch)
     captured: dict[str, object] = {}
 
     class FakeConfidentialClientApplication:
@@ -99,7 +105,8 @@ def test_get_aad_token_uses_configured_auth_timeout(monkeypatch):
             return {"access_token": "aad-token"}
 
     monkeypatch.setattr(
-        "dsis_client.api.auth.auth.msal.ConfidentialClientApplication",
+        auth_module.msal,
+        "ConfidentialClientApplication",
         FakeConfidentialClientApplication,
     )
 
@@ -117,7 +124,7 @@ def test_get_aad_token_uses_configured_auth_timeout(monkeypatch):
 
 def test_get_dsis_token_uses_configured_auth_timeout(monkeypatch):
     """DSIS token POST forwards auth_timeout from DSISConfig."""
-    DSISAuth, DSISConfig, Environment = load_auth_types()
+    _, DSISAuth, DSISConfig, Environment = load_auth_types(monkeypatch)
     captured: dict[str, object] = {}
 
     class FakeResponse:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,157 @@
+"""Tests for DSIS authentication timeout configuration."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import types
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "dsis_client" / "api"
+
+
+def load_auth_types():
+    """Load auth/config modules directly from source without package side effects."""
+    for name in list(sys.modules):
+        if name == "dsis_client" or name.startswith("dsis_client."):
+            sys.modules.pop(name)
+
+    dsis_pkg = types.ModuleType("dsis_client")
+    dsis_pkg.__path__ = [str(ROOT / "src" / "dsis_client")]
+    sys.modules["dsis_client"] = dsis_pkg
+
+    api_pkg = types.ModuleType("dsis_client.api")
+    api_pkg.__path__ = [str(SRC)]
+    sys.modules["dsis_client.api"] = api_pkg
+    dsis_pkg.api = api_pkg
+
+    config_pkg = types.ModuleType("dsis_client.api.config")
+    config_pkg.__path__ = [str(SRC / "config")]
+    sys.modules["dsis_client.api.config"] = config_pkg
+    api_pkg.config = config_pkg
+
+    auth_pkg = types.ModuleType("dsis_client.api.auth")
+    auth_pkg.__path__ = [str(SRC / "auth")]
+    sys.modules["dsis_client.api.auth"] = auth_pkg
+    api_pkg.auth = auth_pkg
+
+    def load_module(name: str, path: Path):
+        spec = spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Unable to load module {name} from {path}")
+        module = module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    load_module("dsis_client.api.exceptions", SRC / "exceptions.py")
+    environment_module = load_module(
+        "dsis_client.api.config.environment", SRC / "config" / "environment.py"
+    )
+    config_module = load_module(
+        "dsis_client.api.config.config", SRC / "config" / "config.py"
+    )
+    config_pkg.environment = environment_module
+    config_pkg.config = config_module
+    config_pkg.DSISConfig = config_module.DSISConfig
+    config_pkg.Environment = environment_module.Environment
+
+    auth_module = load_module("dsis_client.api.auth.auth", SRC / "auth" / "auth.py")
+    auth_pkg.auth = auth_module
+    auth_pkg.DSISAuth = auth_module.DSISAuth
+    return auth_module.DSISAuth, config_module.DSISConfig, environment_module.Environment
+
+
+def make_config(
+    DSISConfig,
+    Environment,
+    *,
+    auth_timeout: float | tuple[float, float] | None = None,
+) -> object:
+    """Create a valid DSISConfig for auth-focused tests."""
+    return DSISConfig(
+        environment=Environment.DEV,
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+        access_app_id="access-app-id",
+        dsis_username="username",
+        dsis_password="password",
+        subscription_key_dsauth="dsauth-key",
+        subscription_key_dsdata="dsdata-key",
+        dsis_site="qa",
+        auth_timeout=auth_timeout,
+    )
+
+
+def test_get_aad_token_uses_configured_auth_timeout(monkeypatch):
+    """MSAL client creation forwards auth_timeout from DSISConfig."""
+    DSISAuth, DSISConfig, Environment = load_auth_types()
+    captured: dict[str, object] = {}
+
+    class FakeConfidentialClientApplication:
+        def __init__(self, client_id, **kwargs):
+            captured["client_id"] = client_id
+            captured["kwargs"] = kwargs
+
+        def acquire_token_for_client(self, scopes):
+            captured["scopes"] = scopes
+            return {"access_token": "aad-token"}
+
+    monkeypatch.setattr(
+        "dsis_client.api.auth.auth.msal.ConfidentialClientApplication",
+        FakeConfidentialClientApplication,
+    )
+
+    auth = DSISAuth(make_config(DSISConfig, Environment, auth_timeout=(5, 30)))
+
+    assert auth.get_aad_token() == "aad-token"
+    assert captured["client_id"] == "client-id"
+    assert captured["scopes"] == ["access-app-id/.default"]
+    assert captured["kwargs"] == {
+        "authority": "https://login.microsoftonline.com/tenant-id",
+        "client_credential": "client-secret",
+        "timeout": (5, 30),
+    }
+
+
+def test_get_dsis_token_uses_configured_auth_timeout(monkeypatch):
+    """DSIS token POST forwards auth_timeout from DSISConfig."""
+    DSISAuth, DSISConfig, Environment = load_auth_types()
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        reason = "OK"
+        text = ""
+
+        @staticmethod
+        def json():
+            return {"access_token": "dsis-token"}
+
+    auth = DSISAuth(make_config(DSISConfig, Environment, auth_timeout=(2, 60)))
+
+    def fake_post(url, *, headers, data, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["data"] = data
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(auth._session, "post", fake_post)
+
+    assert auth.get_dsis_token(aad_token="aad-token") == "dsis-token"
+    assert captured["url"] == "https://api-dev.gateway.equinor.com/dsauth/v1/token"
+    assert captured["headers"] == {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Authorization": "Bearer aad-token",
+        "dsis-site": "qa",
+        "Ocp-Apim-Subscription-Key": "dsauth-key",
+    }
+    assert captured["data"] == {
+        "grant_type": "password",
+        "client_id": "dsis-data",
+        "username": "username",
+        "password": "password",
+    }
+    assert captured["timeout"] == (2, 60)


### PR DESCRIPTION
﻿## Summary
 
 This PR adds first-class timeout configuration for auth-related requests 
in `dsis-client`.
 
 Today the client supports `timeout=` for data-plane calls such as 
`execute_query()`, `get()`, `get_bulk_data()`, and 
`get_bulk_data_stream()`, but Azure AD token acquisition and DSIS token 
requests still do not expose a supported timeout path. That leaves a gap 
where auth can still hang indefintely even when data requests are bounded.
 
 This change adds optional `auth_timeout` to `DSISConfig` and uses it for:
 
 - Azure AD token acquisition via MSAL
 - DSIS token requests via the auth session
 
 This is a non-breaking change. `auth_timeout` is optional, and when it is 
not set the current behavior stays the same.
 
 ## Changes
 
 - add optional `DSISConfig.auth_timeout`
 - forward `auth_timeout` to `msal.ConfidentialClientApplication(..., 
timeout=...)`
 - forward `auth_timeout` to the DSIS token POST request
 - document the new setting in `README.md` and `docs/api/index.md`
 - add focused auth tests for timeout forwarding
 
 ## Notes
 
 - this does not change existing data-plane `timeout=` behavior
 - this does not change the hardcoded `test_connection()` timeout
 - the name `auth_timeout` scopes **which requests** it applies to, not 
only one timeout dimension; like `requests`, it accepts either a single 
value or a `(connect, read)` tuple
 
 ## Testing
 
 - `ruff check src/dsis_client/api/config/config.py 
src/dsis_client/api/auth/auth.py tests/test_auth.py`
 - `python -m pytest tests/test_auth.py -q`
 
 Full local `pytest -q` still hits an existing protobuf runtime mismatch in
 the current environment, unrelated to this PR.
 
 Closes #86