### PR TITLE
feat(bulk-data): accept OData media links for bulk downloads

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -126,15 +126,16 @@ Headers assembled internally include both tokens + subscription key; pass only e
 
 ## Binary Data Methods
 
-### `get_bulk_data(query, *, accept="application/json", timeout=None)`
+### `get_bulk_data(query, *, accept="application/json", timeout=None, media_link=None)`
 
 Fetch binary bulk data (protobuf) for an entity. Loads entire response into memory.
 
 **Parameters:**
 
-- `query`: QueryBuilder instance configured with `.schema()` and `.entity()` calls
+- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the exact OData link returned by DSIS.
 - `accept`: Accept header value (default: `"application/json"`). Use `"application/octet-stream"` for raw binary endpoints (e.g., SurfaceGrid/$value)
 - `timeout`: Request timeout in seconds. `float` for both connect/read, `(float, float)` tuple for separate connect/read timeouts, or `None` for no timeout (default). For streaming, this is not a total download deadline; it applies to connection setup and waiting for the next bytes to arrive.
+- `media_link`: Optional OData media link such as `LogCurve(...)/data`. Relative links are resolved against the query's model/version/district/project context. Service-root-relative paths and full URLs under the configured data endpoint also work.
 
 **Returns:** `Optional[bytes]` - Binary protobuf data or None if no data
 
@@ -154,20 +155,29 @@ query = QueryBuilder(district_id="123", project="SNORRE").schema("SurfaceGrid")
 grids = list(client.execute_query(query))
 bulk_query = query.entity(grids[0]["native_uid"], data_field="$value")
 binary_data = client.get_bulk_data(bulk_query, accept="application/octet-stream")
+
+# Option 3: Use the exact OData media link returned by DSIS
+query = QueryBuilder(district_id="123", project="SNORRE").schema("LogCurve")
+curves = list(client.execute_query(query))
+binary_data = client.get_bulk_data(
+    query,
+    media_link=curves[0]["data@odata.mediaReadLink"],
+)
 ```
 
-### `get_bulk_data_stream(query, *, chunk_size=10*1024*1024, accept="application/json", timeout=None, stream_retries=0, total_timeout=None)`
+### `get_bulk_data_stream(query, *, chunk_size=10*1024*1024, accept="application/json", timeout=None, stream_retries=0, total_timeout=None, media_link=None)`
 
 Stream binary bulk data in chunks for memory-efficient processing.
 
 **Parameters:**
 
-- `query`: QueryBuilder instance configured with `.schema()` and `.entity()` calls
+- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the exact OData link returned by DSIS.
 - `chunk_size`: Size of chunks to yield (default: 10MB, DSIS recommended)
 - `accept`: Accept header value (default: `"application/json"`)
 - `timeout`: Request timeout in seconds. `float` for both connect/read, `(float, float)` tuple for separate connect/read timeouts, or `None` for no timeout (default)
 - `stream_retries`: Number of retry attempts for failures while reading streamed chunks. Retries reopen the stream and assume the endpoint returns the same bytes across reconnects. Default: `0`
 - `total_timeout`: Maximum wall-clock seconds for the entire stream (including retries). `None` means no total timeout (default). Unlike `timeout` which only guards gaps between bytes, this catches slow-trickle streams that never fully stall.
+- `media_link`: Optional OData media link such as `LogCurve(...)/data`. Relative links are resolved against the query's model/version/district/project context. Service-root-relative paths and full URLs under the configured data endpoint also work.
 
 **Yields:** Binary data chunks as bytes
 
@@ -191,6 +201,14 @@ for chunk in client.get_bulk_data_stream(
     chunks.append(chunk)
 
 binary_data = b''.join(chunks)
+
+# Or stream directly from the OData media link
+for chunk in client.get_bulk_data_stream(
+    query,
+    media_link=datasets[0]["data@odata.mediaReadLink"],
+    chunk_size=10*1024*1024,
+):
+    chunks.append(chunk)
 ```
 
 ## Notes

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -132,10 +132,10 @@ Fetch binary bulk data (protobuf) for an entity. Loads entire response into memo
 
 **Parameters:**
 
-- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the exact OData link returned by DSIS.
+- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the relative OData link returned by DSIS.
 - `accept`: Accept header value (default: `"application/json"`). Use `"application/octet-stream"` for raw binary endpoints (e.g., SurfaceGrid/$value)
 - `timeout`: Request timeout in seconds. `float` for both connect/read, `(float, float)` tuple for separate connect/read timeouts, or `None` for no timeout (default). For streaming, this is not a total download deadline; it applies to connection setup and waiting for the next bytes to arrive.
-- `media_link`: Optional OData media link such as `LogCurve(...)/data`. Relative links are resolved against the query's model/version/district/project context. Service-root-relative paths and full URLs under the configured data endpoint also work.
+- `media_link`: Optional relative OData media link such as `LogCurve(...)/data`, as returned by DSIS. It is resolved against the query's model/version/district/project context.
 
 **Returns:** `Optional[bytes]` - Binary protobuf data or None if no data
 
@@ -171,13 +171,13 @@ Stream binary bulk data in chunks for memory-efficient processing.
 
 **Parameters:**
 
-- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the exact OData link returned by DSIS.
+- `query`: QueryBuilder instance configured with `.schema()`. Call `.entity()` for the existing endpoint-building flow, or keep the collection query and pass `media_link=` with the relative OData link returned by DSIS.
 - `chunk_size`: Size of chunks to yield (default: 10MB, DSIS recommended)
 - `accept`: Accept header value (default: `"application/json"`)
 - `timeout`: Request timeout in seconds. `float` for both connect/read, `(float, float)` tuple for separate connect/read timeouts, or `None` for no timeout (default)
 - `stream_retries`: Number of retry attempts for failures while reading streamed chunks. Retries reopen the stream and assume the endpoint returns the same bytes across reconnects. Default: `0`
 - `total_timeout`: Maximum wall-clock seconds for the entire stream (including retries). `None` means no total timeout (default). Unlike `timeout` which only guards gaps between bytes, this catches slow-trickle streams that never fully stall.
-- `media_link`: Optional OData media link such as `LogCurve(...)/data`. Relative links are resolved against the query's model/version/district/project context. Service-root-relative paths and full URLs under the configured data endpoint also work.
+- `media_link`: Optional relative OData media link such as `LogCurve(...)/data`, as returned by DSIS. It is resolved against the query's model/version/district/project context.
 
 **Yields:** Binary data chunks as bytes
 

--- a/docs/guides/query-builder.md
+++ b/docs/guides/query-builder.md
@@ -178,6 +178,8 @@ bulk_query = query.entity("46075", data_field="$value")
 # build_endpoint() → ".../SurfaceGrid('46075')/$value"
 ```
 
+If a DSIS response already includes `odata.mediaReadLink` or `data@odata.mediaReadLink`, you can keep the collection query unchanged and pass that link directly to `client.get_bulk_data(..., media_link=...)` or `client.get_bulk_data_stream(..., media_link=...)`.
+
 ### build_endpoint()
 
 Build the full API endpoint path from the query's configuration.

--- a/docs/guides/query-builder.md
+++ b/docs/guides/query-builder.md
@@ -178,7 +178,7 @@ bulk_query = query.entity("46075", data_field="$value")
 # build_endpoint() → ".../SurfaceGrid('46075')/$value"
 ```
 
-If a DSIS response already includes `odata.mediaReadLink` or `data@odata.mediaReadLink`, you can keep the collection query unchanged and pass that link directly to `client.get_bulk_data(..., media_link=...)` or `client.get_bulk_data_stream(..., media_link=...)`.
+If a DSIS response already includes a relative `odata.mediaReadLink` or `data@odata.mediaReadLink`, you can keep the collection query unchanged and pass that link directly to `client.get_bulk_data(..., media_link=...)` or `client.get_bulk_data_stream(..., media_link=...)`.
 
 ### build_endpoint()
 

--- a/docs/guides/working-with-binary-data.md
+++ b/docs/guides/working-with-binary-data.md
@@ -106,7 +106,7 @@ bulk_query = query.entity("46075", data_field="$value")
 binary_data = client.get_bulk_data(bulk_query, accept="application/octet-stream")
 ```
 
-If DSIS already returned an OData media link for the row, you can pass that link directly to the bulk-data methods instead of rebuilding an entity endpoint:
+If DSIS already returned a relative OData media link for the row, you can pass that link directly to the bulk-data methods instead of rebuilding an entity endpoint:
 
 ```python
 query = QueryBuilder(
@@ -337,7 +337,7 @@ Retries reopen the stream and resume after the bytes already yielded, so this sh
 
 - **Standard bulk data**: `query.entity(native_uid)` → `/{Schema}('{native_uid}')/data`
 - **Surface grids**: `query.entity(native_uid, data_field="$value")` → `/{Schema}('{native_uid}')/$value`
-- **Exact OData links**: `client.get_bulk_data(query, media_link=row["data@odata.mediaReadLink"])`
+- **Exact relative OData links**: `client.get_bulk_data(query, media_link=row["data@odata.mediaReadLink"])`
 
 ### Accept Header
 

--- a/docs/guides/working-with-binary-data.md
+++ b/docs/guides/working-with-binary-data.md
@@ -106,6 +106,31 @@ bulk_query = query.entity("46075", data_field="$value")
 binary_data = client.get_bulk_data(bulk_query, accept="application/octet-stream")
 ```
 
+If DSIS already returned an OData media link for the row, you can pass that link directly to the bulk-data methods instead of rebuilding an entity endpoint:
+
+```python
+query = QueryBuilder(
+    model_name="RecallCommonModel",
+    model_version="500010",
+    district_id="RecallCommonModel_OFDB_RecallProd-RecallProd",
+    project="NORWAY_WELLDB",
+).schema("LogCurve")
+
+curves = list(client.execute_query(query, max_pages=1))
+
+binary_data = client.get_bulk_data(
+    query,
+    media_link=curves[0]["data@odata.mediaReadLink"],
+)
+
+for chunk in client.get_bulk_data_stream(
+    query,
+    media_link=curves[0]["data@odata.mediaReadLink"],
+    chunk_size=10 * 1024 * 1024,
+):
+    ...
+```
+
 ## Complete Examples
 
 ### Example 1: Horizon Data
@@ -312,6 +337,7 @@ Retries reopen the stream and resume after the bytes already yielded, so this sh
 
 - **Standard bulk data**: `query.entity(native_uid)` → `/{Schema}('{native_uid}')/data`
 - **Surface grids**: `query.entity(native_uid, data_field="$value")` → `/{Schema}('{native_uid}')/$value`
+- **Exact OData links**: `client.get_bulk_data(query, media_link=row["data@odata.mediaReadLink"])`
 
 ### Accept Header
 

--- a/src/dsis_client/api/client/_bulk_data.py
+++ b/src/dsis_client/api/client/_bulk_data.py
@@ -5,6 +5,7 @@ Provides mixin class for fetching binary protobuf data.
 
 import logging
 from typing import TYPE_CHECKING, Generator, Optional, Union
+from urllib.parse import urlparse
 
 from ._base import _BinaryRequestBase
 
@@ -21,26 +22,87 @@ class BulkDataMixin(_BinaryRequestBase):
     Requires subclasses to provide: config, _request_binary, _request_binary_stream.
     """
 
+    @staticmethod
+    def _build_bulk_query_root(query: "QueryBuilder") -> str:
+        """Build the DSIS path prefix before a collection/media-link segment."""
+        if not query._schema_name:
+            raise ValueError(
+                "Query must define a schema. "
+                "Call query.schema(...) before passing it to bulk data methods."
+            )
+
+        segments = [query.model_name, query.model_version]
+        if query.district_id is not None:
+            segments.append(str(query.district_id))
+        if query.project is not None:
+            segments.append(query.project)
+        return "/".join(segments)
+
+    def _resolve_bulk_endpoint(
+        self,
+        query: "QueryBuilder",
+        media_link: Optional[str] = None,
+    ) -> str:
+        """Resolve a bulk-data endpoint from entity targeting or an OData media link."""
+        if media_link is None:
+            if query._native_uid is None:
+                raise ValueError(
+                    "Query must target an entity. "
+                    "Call query.entity(native_uid) before passing to get_bulk_data()."
+                )
+            return query.build_endpoint()
+
+        media_link = media_link.strip()
+        if not media_link:
+            raise ValueError("media_link must be a non-empty string")
+
+        data_endpoint = self.config.data_endpoint.rstrip("/")
+        if media_link.startswith(f"{data_endpoint}/"):
+            return media_link[len(data_endpoint) + 1 :]
+
+        parsed_link = urlparse(media_link)
+        if parsed_link.scheme or parsed_link.netloc:
+            raise ValueError(
+                "media_link must be relative to the configured DSIS data endpoint "
+                "or use that exact endpoint as its base URL"
+            )
+
+        normalized_link = media_link.lstrip("/")
+        configured_path = urlparse(data_endpoint).path.strip("/")
+        if configured_path and normalized_link.startswith(f"{configured_path}/"):
+            return normalized_link[len(configured_path) + 1 :]
+
+        query_root = self._build_bulk_query_root(query)
+        if normalized_link.startswith(f"{query_root}/"):
+            return normalized_link
+
+        return f"{query_root}/{normalized_link}"
+
     def get_bulk_data(
         self,
         query: "QueryBuilder",
         *,
         accept: str = "application/json",
         timeout: Optional[Union[float, tuple[float, float]]] = None,
+        media_link: Optional[str] = None,
     ) -> Optional[bytes]:
         """Fetch binary bulk data (protobuf) for a specific entity.
 
-        The query must have been configured with ``.entity(native_uid)`` to
-        target a specific entity's binary data field.
+        By default, the query must have been configured with
+        ``.entity(native_uid)`` to target a specific entity's binary data field.
+        When ``media_link`` is provided, the query only needs ``.schema()`` and
+        the exact OData media link path returned by DSIS can be used directly.
 
         The DSIS API serves large binary data fields (horizon z-values, log curves,
         seismic amplitudes) as Protocol Buffers via a special OData endpoint:
         ``/{schema}('{native_uid}')/{data_field}``
 
         Args:
-            query: A QueryBuilder instance configured with ``.schema()`` and
-                ``.entity()`` calls. Holds model, district, project, schema,
-                native_uid, and data_field.
+            query: A QueryBuilder instance configured with ``.schema()``.
+                Call ``.entity()`` for the existing endpoint-building flow, or
+                keep the collection query and pass ``media_link`` with the exact
+                OData link returned by DSIS. Holds model, district, project,
+                schema, native_uid, and data_field.
             accept: Accept header value for the HTTP request
                 (default: ``"application/json"``). Use ``"application/octet-stream"``
                 for endpoints that serve raw binary data (e.g., SurfaceGrid/$value).
@@ -49,12 +111,17 @@ class BulkDataMixin(_BinaryRequestBase):
                 None means no timeout (default). For streamed downloads this
                 applies to connection setup and waiting for the next bytes to
                 arrive, not to the total download duration.
+            media_link: Optional OData media link path returned by DSIS
+                (for example ``LogCurve(...)/data``). Relative media links are
+                resolved against the query's model/version/district/project
+                context. Service-root-relative paths and full URLs pointing to
+                the configured data endpoint are also accepted.
 
         Returns:
             Binary protobuf data as bytes, or None if the entity has no bulk data
 
         Raises:
-            ValueError: If query has no entity set
+            ValueError: If query has no entity set and no media_link is provided
             DSISAPIError: If the API request fails (other than 404 for missing data)
 
         Example:
@@ -70,21 +137,17 @@ class BulkDataMixin(_BinaryRequestBase):
             ... )
             >>> curves = list(client.execute_query(query))
             >>>
-            >>> # Fetch binary data by targeting a specific entity
-            >>> bulk_query = query.entity(curves[0]["native_uid"])
-            >>> binary_data = client.get_bulk_data(bulk_query)
+            >>> # Fetch binary data using the exact media link returned by DSIS
+            >>> binary_data = client.get_bulk_data(
+            ...     query,
+            ...     media_link=curves[0]["data@odata.mediaReadLink"],
+            ... )
             >>>
             >>> if binary_data:
             ...     from dsis_model_sdk.protobuf import decode_log_curves
             ...     decoded = decode_log_curves(binary_data)
         """
-        if query._native_uid is None:
-            raise ValueError(
-                "Query must target an entity. "
-                "Call query.entity(native_uid) before passing to get_bulk_data()."
-            )
-
-        endpoint = query.build_endpoint()
+        endpoint = self._resolve_bulk_endpoint(query, media_link=media_link)
         logger.info(f"Fetching bulk data from: {endpoint}")
         return self._request_binary(endpoint, accept=accept, timeout=timeout)
 
@@ -97,19 +160,24 @@ class BulkDataMixin(_BinaryRequestBase):
         timeout: Optional[Union[float, tuple[float, float]]] = None,
         stream_retries: int = 0,
         total_timeout: Optional[float] = None,
+        media_link: Optional[str] = None,
     ) -> Generator[bytes, None, None]:
         """Stream binary bulk data (protobuf) in chunks for memory-efficient processing.
 
-        The query must have been configured with ``.entity(native_uid)`` to
-        target a specific entity's binary data field.
+        By default, the query must have been configured with
+        ``.entity(native_uid)`` to target a specific entity's binary data field.
+        When ``media_link`` is provided, the query only needs ``.schema()`` and
+        the exact OData media link path returned by DSIS can be used directly.
 
         This streaming version yields data in chunks rather than loading everything
         into memory at once. Useful for very large datasets (e.g., seismic volumes).
 
         Args:
-            query: A QueryBuilder instance configured with ``.schema()`` and
-                ``.entity()`` calls. Holds model, district, project, schema,
-                native_uid, and data_field.
+            query: A QueryBuilder instance configured with ``.schema()``.
+                Call ``.entity()`` for the existing endpoint-building flow, or
+                keep the collection query and pass ``media_link`` with the exact
+                OData link returned by DSIS. Holds model, district, project,
+                schema, native_uid, and data_field.
             chunk_size: Size of chunks to yield in bytes
                 (default: 10MB, recommended by DSIS)
             accept: Accept header value for the HTTP request
@@ -125,12 +193,17 @@ class BulkDataMixin(_BinaryRequestBase):
                 (including retries). None means no total timeout (default).
                 Unlike ``timeout`` which only guards gaps between bytes, this
                 catches slow-trickle streams that never fully stall.
+            media_link: Optional OData media link path returned by DSIS
+                (for example ``LogCurve(...)/data``). Relative media links are
+                resolved against the query's model/version/district/project
+                context. Service-root-relative paths and full URLs pointing to
+                the configured data endpoint are also accepted.
 
         Yields:
             Binary data chunks as bytes. Returns immediately if no bulk data (404).
 
         Raises:
-            ValueError: If query has no entity set
+            ValueError: If query has no entity set and no media_link is provided
             DSISAPIError: If the API request fails (other than 404 for missing data)
 
         Example:
@@ -145,18 +218,22 @@ class BulkDataMixin(_BinaryRequestBase):
             ... )
             >>> datasets = list(client.execute_query(query))
             >>>
-            >>> bulk_query = query.entity(datasets[0]["native_uid"])
-            >>> chunks = list(client.get_bulk_data_stream(bulk_query))
+            >>> chunks = list(
+            ...     client.get_bulk_data_stream(
+            ...         query,
+            ...         media_link=datasets[0]["data@odata.mediaReadLink"],
+            ...     )
+            ... )
             >>> if chunks:
             ...     binary_data = b"".join(chunks)
         """
-        if query._native_uid is None:
+        if media_link is None and query._native_uid is None:
             raise ValueError(
                 "Query must target an entity. "
                 "Call query.entity(native_uid) before passing to get_bulk_data_stream()."
             )
 
-        endpoint = query.build_endpoint()
+        endpoint = self._resolve_bulk_endpoint(query, media_link=media_link)
         logger.info(f"Streaming bulk data from: {endpoint} (chunk_size={chunk_size})")
         yield from self._request_binary_stream(
             endpoint,

--- a/src/dsis_client/api/client/_bulk_data.py
+++ b/src/dsis_client/api/client/_bulk_data.py
@@ -56,27 +56,19 @@ class BulkDataMixin(_BinaryRequestBase):
         if not media_link:
             raise ValueError("media_link must be a non-empty string")
 
-        data_endpoint = self.config.data_endpoint.rstrip("/")
-        if media_link.startswith(f"{data_endpoint}/"):
-            return media_link[len(data_endpoint) + 1 :]
-
         parsed_link = urlparse(media_link)
-        if parsed_link.scheme or parsed_link.netloc:
+        if parsed_link.scheme or parsed_link.netloc or media_link.startswith("/"):
             raise ValueError(
-                "media_link must be relative to the configured DSIS data endpoint "
-                "or use that exact endpoint as its base URL"
+                'media_link must be a relative OData media link such as "LogCurve(...)/data"'
             )
 
-        normalized_link = media_link.lstrip("/")
-        configured_path = urlparse(data_endpoint).path.strip("/")
-        if configured_path and normalized_link.startswith(f"{configured_path}/"):
-            return normalized_link[len(configured_path) + 1 :]
-
         query_root = self._build_bulk_query_root(query)
-        if normalized_link.startswith(f"{query_root}/"):
-            return normalized_link
+        if media_link.startswith(f"{query_root}/"):
+            raise ValueError(
+                'media_link must be a relative OData media link such as "LogCurve(...)/data"'
+            )
 
-        return f"{query_root}/{normalized_link}"
+        return f"{query_root}/{media_link}"
 
     def get_bulk_data(
         self,
@@ -112,10 +104,9 @@ class BulkDataMixin(_BinaryRequestBase):
                 applies to connection setup and waiting for the next bytes to
                 arrive, not to the total download duration.
             media_link: Optional OData media link path returned by DSIS
-                (for example ``LogCurve(...)/data``). Relative media links are
-                resolved against the query's model/version/district/project
-                context. Service-root-relative paths and full URLs pointing to
-                the configured data endpoint are also accepted.
+                (for example ``LogCurve(...)/data``). The link must be the
+                relative row-level media link returned by DSIS and is resolved
+                against the query's model/version/district/project context.
 
         Returns:
             Binary protobuf data as bytes, or None if the entity has no bulk data
@@ -194,10 +185,9 @@ class BulkDataMixin(_BinaryRequestBase):
                 Unlike ``timeout`` which only guards gaps between bytes, this
                 catches slow-trickle streams that never fully stall.
             media_link: Optional OData media link path returned by DSIS
-                (for example ``LogCurve(...)/data``). Relative media links are
-                resolved against the query's model/version/district/project
-                context. Service-root-relative paths and full URLs pointing to
-                the configured data endpoint are also accepted.
+                (for example ``LogCurve(...)/data``). The link must be the
+                relative row-level media link returned by DSIS and is resolved
+                against the query's model/version/district/project context.
 
         Yields:
             Binary data chunks as bytes. Returns immediately if no bulk data (404).

--- a/tests/test_bulk_data_media_link.py
+++ b/tests/test_bulk_data_media_link.py
@@ -47,7 +47,9 @@ def load_bulk_data_types(monkeypatch):
         spec.loader.exec_module(module)
         return module
 
-    odata_module = load_module("dsis_client.api.query.odata", SRC / "query" / "odata.py")
+    odata_module = load_module(
+        "dsis_client.api.query.odata", SRC / "query" / "odata.py"
+    )
     builder_module = load_module(
         "dsis_client.api.query.builder", SRC / "query" / "builder.py"
     )
@@ -55,7 +57,9 @@ def load_bulk_data_types(monkeypatch):
     query_pkg.builder = builder_module
     query_pkg.QueryBuilder = builder_module.QueryBuilder
 
-    base_module = load_module("dsis_client.api.client._base", SRC / "client" / "_base.py")
+    base_module = load_module(
+        "dsis_client.api.client._base", SRC / "client" / "_base.py"
+    )
     bulk_data_module = load_module(
         "dsis_client.api.client._bulk_data", SRC / "client" / "_bulk_data.py"
     )

--- a/tests/test_bulk_data_media_link.py
+++ b/tests/test_bulk_data_media_link.py
@@ -206,36 +206,31 @@ def test_get_bulk_data_stream_accepts_media_link(monkeypatch):
     ]
 
 
-def test_get_bulk_data_accepts_full_data_endpoint_url(monkeypatch):
-    """Full URLs under the configured data endpoint are normalized."""
+def test_get_bulk_data_rejects_absolute_media_link(monkeypatch):
+    """Absolute URLs are outside the supported media_link contract."""
     BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
     client = make_client(BulkDataMixin)
     query = make_query(QueryBuilder)
 
-    payload = client.get_bulk_data(
-        query,
-        media_link=(
-            "https://example.org/dsdata/v1/RecallCommonModel/500010/"
-            "RecallCommonModel_OFDB_RecallProd-RecallProd/NORWAY_WELLDB/"
-            "LogCurve('44367/6')/data"
-        ),
-    )
-
-    assert payload == b"payload"
-    assert client.binary_calls[0]["endpoint"] == (
-        "RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/"
-        "NORWAY_WELLDB/LogCurve('44367/6')/data"
-    )
-
-
-def test_get_bulk_data_rejects_media_link_for_other_service(monkeypatch):
-    """Absolute URLs must point at the configured DSIS data endpoint."""
-    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
-    client = make_client(BulkDataMixin)
-    query = make_query(QueryBuilder)
-
-    with pytest.raises(ValueError, match="configured DSIS data endpoint"):
+    with pytest.raises(ValueError, match="relative OData media link"):
         client.get_bulk_data(
             query,
-            media_link="https://other.example.org/dsdata/v1/LogCurve('44367/6')/data",
+            media_link=(
+                "https://example.org/dsdata/v1/RecallCommonModel/500010/"
+                "RecallCommonModel_OFDB_RecallProd-RecallProd/NORWAY_WELLDB/"
+                "LogCurve('44367/6')/data"
+            ),
+        )
+
+
+def test_get_bulk_data_rejects_service_root_relative_media_link(monkeypatch):
+    """Service-root-relative media links are outside the supported contract."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder)
+
+    with pytest.raises(ValueError, match="relative OData media link"):
+        client.get_bulk_data(
+            query,
+            media_link="/RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/NORWAY_WELLDB/LogCurve('44367/6')/data",
         )

--- a/tests/test_bulk_data_media_link.py
+++ b/tests/test_bulk_data_media_link.py
@@ -1,0 +1,237 @@
+"""Focused tests for bulk data media-link support."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import types
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "dsis_client" / "api"
+
+
+def load_bulk_data_types(monkeypatch):
+    """Load query and bulk-data modules directly from source."""
+    for name in list(sys.modules):
+        if name == "dsis_client" or name.startswith("dsis_client."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    dsis_pkg = types.ModuleType("dsis_client")
+    dsis_pkg.__path__ = [str(ROOT / "src" / "dsis_client")]
+    monkeypatch.setitem(sys.modules, "dsis_client", dsis_pkg)
+
+    api_pkg = types.ModuleType("dsis_client.api")
+    api_pkg.__path__ = [str(SRC)]
+    monkeypatch.setitem(sys.modules, "dsis_client.api", api_pkg)
+    dsis_pkg.api = api_pkg
+
+    query_pkg = types.ModuleType("dsis_client.api.query")
+    query_pkg.__path__ = [str(SRC / "query")]
+    monkeypatch.setitem(sys.modules, "dsis_client.api.query", query_pkg)
+    api_pkg.query = query_pkg
+
+    client_pkg = types.ModuleType("dsis_client.api.client")
+    client_pkg.__path__ = [str(SRC / "client")]
+    monkeypatch.setitem(sys.modules, "dsis_client.api.client", client_pkg)
+    api_pkg.client = client_pkg
+
+    def load_module(name: str, path: Path):
+        spec = spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Unable to load module {name} from {path}")
+        module = module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, name, module)
+        spec.loader.exec_module(module)
+        return module
+
+    odata_module = load_module("dsis_client.api.query.odata", SRC / "query" / "odata.py")
+    builder_module = load_module(
+        "dsis_client.api.query.builder", SRC / "query" / "builder.py"
+    )
+    query_pkg.odata = odata_module
+    query_pkg.builder = builder_module
+    query_pkg.QueryBuilder = builder_module.QueryBuilder
+
+    base_module = load_module("dsis_client.api.client._base", SRC / "client" / "_base.py")
+    bulk_data_module = load_module(
+        "dsis_client.api.client._bulk_data", SRC / "client" / "_bulk_data.py"
+    )
+    client_pkg._base = base_module
+    client_pkg._bulk_data = bulk_data_module
+
+    return bulk_data_module.BulkDataMixin, builder_module.QueryBuilder
+
+
+def make_client(BulkDataMixin):
+    """Create a minimal client that records bulk-data calls."""
+
+    class FakeClient(BulkDataMixin):
+        def __init__(self) -> None:
+            self.config = SimpleNamespace(data_endpoint="https://example.org/dsdata/v1")
+            self.binary_calls: list[dict[str, object]] = []
+            self.stream_calls: list[dict[str, object]] = []
+
+        def _request_binary(
+            self, endpoint, params=None, accept="application/json", timeout=None
+        ):
+            self.binary_calls.append(
+                {
+                    "endpoint": endpoint,
+                    "params": params,
+                    "accept": accept,
+                    "timeout": timeout,
+                }
+            )
+            return b"payload"
+
+        def _request_binary_stream(
+            self,
+            endpoint,
+            params=None,
+            chunk_size=10 * 1024 * 1024,
+            accept="application/json",
+            timeout=None,
+            stream_retries=0,
+            total_timeout=None,
+        ):
+            self.stream_calls.append(
+                {
+                    "endpoint": endpoint,
+                    "params": params,
+                    "chunk_size": chunk_size,
+                    "accept": accept,
+                    "timeout": timeout,
+                    "stream_retries": stream_retries,
+                    "total_timeout": total_timeout,
+                }
+            )
+            yield b"chunk-one"
+            yield b"chunk-two"
+
+    return FakeClient()
+
+
+def make_query(QueryBuilder):
+    """Create a query matching the WellLog case from <issue>:75."""
+    return QueryBuilder(
+        model_name="RecallCommonModel",
+        model_version="500010",
+        district_id="RecallCommonModel_OFDB_RecallProd-RecallProd",
+        project="NORWAY_WELLDB",
+    ).schema("LogCurve")
+
+
+def test_get_bulk_data_accepts_relative_media_link(monkeypatch):
+    """Relative OData media links resolve against the base query context."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder)
+    media_link = (
+        "LogCurve(log_crv_name='LFP_VPVS_LOG',log_crv_version=1,"
+        "log_name='GeologLFP',log_pass_id='NONE',log_run_no=-1,wellid='52')/data"
+    )
+
+    payload = client.get_bulk_data(query, media_link=media_link, timeout=(5, 30))
+
+    assert payload == b"payload"
+    assert client.binary_calls == [
+        {
+            "endpoint": (
+                "RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/"
+                "NORWAY_WELLDB/"
+                "LogCurve(log_crv_name='LFP_VPVS_LOG',log_crv_version=1,"
+                "log_name='GeologLFP',log_pass_id='NONE',log_run_no=-1,wellid='52')/data"
+            ),
+            "params": None,
+            "accept": "application/json",
+            "timeout": (5, 30),
+        }
+    ]
+
+
+def test_get_bulk_data_preserves_entity_based_behavior(monkeypatch):
+    """Existing entity-targeting behavior remains unchanged."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder).entity("44367/6")
+
+    payload = client.get_bulk_data(query)
+
+    assert payload == b"payload"
+    assert client.binary_calls[0]["endpoint"] == (
+        "RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/"
+        "NORWAY_WELLDB/LogCurve('44367/6')/data"
+    )
+
+
+def test_get_bulk_data_stream_accepts_media_link(monkeypatch):
+    """Streaming bulk data also accepts the exact OData media link."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder)
+
+    chunks = list(
+        client.get_bulk_data_stream(
+            query,
+            media_link="LogCurve('44367/6')/data",
+            chunk_size=4,
+            accept="application/octet-stream",
+            timeout=60,
+            stream_retries=2,
+            total_timeout=120,
+        )
+    )
+
+    assert chunks == [b"chunk-one", b"chunk-two"]
+    assert client.stream_calls == [
+        {
+            "endpoint": (
+                "RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/"
+                "NORWAY_WELLDB/LogCurve('44367/6')/data"
+            ),
+            "params": None,
+            "chunk_size": 4,
+            "accept": "application/octet-stream",
+            "timeout": 60,
+            "stream_retries": 2,
+            "total_timeout": 120,
+        }
+    ]
+
+
+def test_get_bulk_data_accepts_full_data_endpoint_url(monkeypatch):
+    """Full URLs under the configured data endpoint are normalized."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder)
+
+    payload = client.get_bulk_data(
+        query,
+        media_link=(
+            "https://example.org/dsdata/v1/RecallCommonModel/500010/"
+            "RecallCommonModel_OFDB_RecallProd-RecallProd/NORWAY_WELLDB/"
+            "LogCurve('44367/6')/data"
+        ),
+    )
+
+    assert payload == b"payload"
+    assert client.binary_calls[0]["endpoint"] == (
+        "RecallCommonModel/500010/RecallCommonModel_OFDB_RecallProd-RecallProd/"
+        "NORWAY_WELLDB/LogCurve('44367/6')/data"
+    )
+
+
+def test_get_bulk_data_rejects_media_link_for_other_service(monkeypatch):
+    """Absolute URLs must point at the configured DSIS data endpoint."""
+    BulkDataMixin, QueryBuilder = load_bulk_data_types(monkeypatch)
+    client = make_client(BulkDataMixin)
+    query = make_query(QueryBuilder)
+
+    with pytest.raises(ValueError, match="configured DSIS data endpoint"):
+        client.get_bulk_data(
+            query,
+            media_link="https://other.example.org/dsdata/v1/LogCurve('44367/6')/data",
+        )


### PR DESCRIPTION
Add a non-breaking media_link option to get_bulk_data() and get_bulk_data_stream() so callers can use the exact OData links returned by DSIS instead of rebuilding entity endpoints.

Keep the existing QueryBuilder.entity() flow intact and document the new direct media-link usage with focused tests.